### PR TITLE
Bump mod to 2.0.0

### DIFF
--- a/OurMod/build.gradle
+++ b/OurMod/build.gradle
@@ -7,7 +7,7 @@ plugins {
 }
 
 group = 'com.example.ourmod'
-version = '1.1.1'
+version = '2.0.0'
 
 base {
     archivesName = 'ourmod'
@@ -73,7 +73,7 @@ tasks.named('processResources', ProcessResources).configure {
         mod_id                 : 'ourmod',
         mod_name               : 'OurMod',
         mod_license            : 'All Rights Reserved',
-        mod_version            : '1.1.1',
+        mod_version            : '2.0.0',
         mod_authors            : 'Big Ev',
         mod_description        : 'A simple test mod.'
     ]

--- a/OurMod/changelog.txt
+++ b/OurMod/changelog.txt
@@ -5,4 +5,4 @@
 Big
 - 1.0.0 built the thing and called it our mod | 6/29/2025
 - 1.1.0 made the command /lockon and the command /unlock | 6/30/2025
-- 1.1.1 fixed the smoothing look | 6/30/25
+- 2.0.0 fixed the smoothing look | 6/30/25

--- a/OurMod/gradle.properties
+++ b/OurMod/gradle.properties
@@ -48,7 +48,7 @@ mod_name=Example Mod
 # The license of the mod. Review your options at https://choosealicense.com/. All Rights Reserved is the default.
 mod_license=All Rights Reserved
 # The mod version. See https://semver.org/
-mod_version=1.0.0
+mod_version=2.0.0
 # The group ID for the mod. It is only important when publishing as an artifact to a Maven repository.
 # This should match the base package used for the mod sources.
 # See https://maven.apache.org/guides/mini/guide-naming-conventions.html

--- a/OurMod/src/main/java/com/example/ourmod/OurMod.java
+++ b/OurMod/src/main/java/com/example/ourmod/OurMod.java
@@ -76,7 +76,7 @@ public class OurMod {
 
     private void commonSetup(final FMLCommonSetupEvent event) {
         LOGGER.info("HELLO FROM COMMON SETUP");
-        LOGGER.info("OurMod v1.1.0 loaded successfully.");
+        LOGGER.info("OurMod v2.0.0 loaded successfully.");
 
         if (Config.logDirtBlock) {
             LOGGER.info("DIRT BLOCK >> {}", ForgeRegistries.BLOCKS.getKey(Blocks.DIRT));

--- a/OurMod/src/main/resources/META-INF/mods.toml
+++ b/OurMod/src/main/resources/META-INF/mods.toml
@@ -4,7 +4,7 @@ license="All Rights Reserved"
 
 [[mods]]
 modId="ourmod"
-version="1.1.1"
+version="2.0.0"
 displayName="OurMod"
 displayURL="https://example.com"
 logoFile=""

--- a/README.md
+++ b/README.md
@@ -285,7 +285,7 @@ public class OurMod {
 
     private void commonSetup(final FMLCommonSetupEvent event) {
         LOGGER.info("HELLO FROM COMMON SETUP");
-        LOGGER.info("OurMod v1.1.0 loaded successfully.");
+        LOGGER.info("OurMod v2.0.0 loaded successfully.");
 
         if (Config.logDirtBlock) {
             LOGGER.info("DIRT BLOCK >> {}", ForgeRegistries.BLOCKS.getKey(Blocks.DIRT));


### PR DESCRIPTION
## Summary
- update build configuration and metadata to version `2.0.0`
- update code and README snippets with the new version
- adjust changelog entry to reflect the new version

## Testing
- `./gradlew --version` *(fails: Could not find or load main class org.gradle.wrapper.GradleWrapperMain)*

------
https://chatgpt.com/codex/tasks/task_e_6866e2a697408333a04cb9f094e36dba