### PR TITLE
Handle websocket start failures

### DIFF
--- a/OurMod/build.gradle
+++ b/OurMod/build.gradle
@@ -58,10 +58,30 @@ repositories {
     mavenCentral()
 }
 
+configurations {
+    embed
+}
+
 dependencies {
     minecraft "net.minecraftforge:forge:1.20.1-47.4.3"
     implementation 'org.java-websocket:Java-WebSocket:1.5.3'
+    embed 'org.java-websocket:Java-WebSocket:1.5.3'
     testImplementation 'org.junit.jupiter:junit-jupiter:5.10.0'
+}
+
+tasks.register('copyEmbedDeps', Sync) {
+    from { configurations.embed.collect { it.isDirectory() ? it : zipTree(it) } }
+    into "$buildDir/classes/java/main"
+    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+}
+
+tasks.named('compileJava').configure {
+    dependsOn tasks.copyEmbedDeps
+}
+
+// Ensure embedded dependencies are copied before running from source
+tasks.withType(JavaExec).matching { it.name.startsWith('run') }.configureEach {
+    dependsOn tasks.copyEmbedDeps
 }
 
 tasks.named('processResources', ProcessResources).configure {
@@ -88,6 +108,7 @@ tasks.named('processResources', ProcessResources).configure {
 // Ensure default jar task is enabled
 tasks.named('jar', Jar).configure {
     enabled = true
+    dependsOn tasks.jarJar
 }
 
 // Configure shadowJar (fat jar with relocation)

--- a/OurMod/src/main/java/com/example/ourmod/OurMod.java
+++ b/OurMod/src/main/java/com/example/ourmod/OurMod.java
@@ -111,7 +111,7 @@ public class OurMod {
             webSocketServer.broadcast("Server started");
             broadcastToPlayers(Component.literal("WebSocket server listening on port " + actualWebSocketPort));
             return true;
-        } catch (Exception e) {
+        } catch (Throwable e) {
             LOGGER.error("WebSocket server failed to start", e);
             webSocketServer = null;
             actualWebSocketPort = -1;


### PR DESCRIPTION
## Summary
- prevent the WebSocket startup from crashing the game by catching all Throwables when starting the server
- ensure the Java-WebSocket library is available when running from source sets
- make run tasks depend on copying embedded dependencies

## Testing
- `gradle -p OurMod build --no-daemon`


------
https://chatgpt.com/codex/tasks/task_e_68681d5a1bf4833393bb94db790759fd