### PR TITLE
Start WebSocket via command

### DIFF
--- a/OurMod/src/main/java/com/example/ourmod/OurMod.java
+++ b/OurMod/src/main/java/com/example/ourmod/OurMod.java
@@ -19,7 +19,6 @@ import net.minecraft.world.level.material.MapColor;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.event.BuildCreativeModeTabContentsEvent;
-import net.minecraftforge.event.server.ServerStartedEvent;
 import net.minecraftforge.event.server.ServerStoppingEvent;
 import com.example.ourmod.Config;
 import net.minecraftforge.eventbus.api.IEventBus;
@@ -40,9 +39,9 @@ public class OurMod {
     private static final Logger LOGGER = LogUtils.getLogger();
     private static OurMod INSTANCE;
     private static final int DEFAULT_WEBSOCKET_PORT = 9001;
-    private WebSocketTNTListener webSocketServer;
-    private volatile boolean webSocketRunning;
-    private int actualWebSocketPort = -1;
+    private static WebSocketTNTListener webSocketServer;
+    private static volatile boolean webSocketRunning;
+    private static int actualWebSocketPort = -1;
 
     public static final DeferredRegister<Block> BLOCKS = DeferredRegister.create(ForgeRegistries.BLOCKS, MODID);
     public static final DeferredRegister<Item> ITEMS = DeferredRegister.create(ForgeRegistries.ITEMS, MODID);
@@ -104,8 +103,15 @@ public class OurMod {
 
         try {
             webSocketServer = new WebSocketTNTListener(configuredPort);
-            webSocketServer.start();
-            actualWebSocketPort = webSocketServer.getPort();
+            Thread t = new Thread(() -> {
+                try {
+                    webSocketServer.start();
+                } catch (Exception e) {
+                    LOGGER.error("WebSocket server thread failed", e);
+                }
+            }, "WebSocketServer");
+            t.start();
+            actualWebSocketPort = configuredPort;
             webSocketRunning = true;
             LOGGER.info("WebSocket server started on ws://localhost:{}", actualWebSocketPort);
             webSocketServer.broadcast("Server started");
@@ -181,22 +187,13 @@ public class OurMod {
         LOGGER.info(Config.magicNumberIntroduction + Config.magicNumber);
         Config.items.forEach(item -> LOGGER.info("ITEM >> {}", item.toString()));
 
-        // WebSocket server will be started when the Minecraft server starts
+        // WebSocket server can be started later via the /websocket command
     }
 
     private void addCreative(BuildCreativeModeTabContentsEvent event) {
         if (event.getTabKey() == CreativeModeTabs.BUILDING_BLOCKS) {
             event.accept(EXAMPLE_BLOCK_ITEM);
         }
-    }
-
-    @SubscribeEvent
-    public void onServerStarted(ServerStartedEvent event) {
-        if (!Config.enableWebSocket) {
-            LOGGER.info("WebSocket server disabled by config");
-            return;
-        }
-        startWebSocket();
     }
 
     @SubscribeEvent

--- a/OurMod/src/main/java/com/example/ourmod/WebSocketCommand.java
+++ b/OurMod/src/main/java/com/example/ourmod/WebSocketCommand.java
@@ -21,16 +21,25 @@ public class WebSocketCommand {
                             ctx.getSource().sendFailure(Component.literal("WebSocket disabled in config."));
                             return 0;
                         }
-                        boolean ok = OurMod.getInstance().startWebSocket();
-                        if (ok) {
-                            int p = OurMod.getInstance().getRunningWebSocketPort();
-                            ctx.getSource().sendSuccess(() -> Component.literal("WebSocket server started on port " + p), false);
-                            return Command.SINGLE_SUCCESS;
-                        } else {
+
+                        if (OurMod.getInstance().isWebSocketRunning()) {
                             int p = OurMod.getInstance().getRunningWebSocketPort();
                             ctx.getSource().sendFailure(Component.literal("WebSocket server already running on port " + p));
                             return 0;
                         }
+
+                        CommandSourceStack source = ctx.getSource();
+                        new Thread(() -> {
+                            boolean ok = OurMod.getInstance().startWebSocket();
+                            if (ok) {
+                                int p = OurMod.getInstance().getRunningWebSocketPort();
+                                source.sendSuccess(() -> Component.literal("WebSocket server started on port " + p), false);
+                            } else {
+                                source.sendFailure(Component.literal("Failed to start WebSocket server"));
+                            }
+                        }, "WebSocketStartCommand").start();
+
+                        return Command.SINGLE_SUCCESS;
                     }))
                 .then(Commands.literal("stop")
                     .executes(ctx -> {

--- a/README.md
+++ b/README.md
@@ -319,16 +319,7 @@ public class OurMod {
         LOGGER.info(Config.magicNumberIntroduction + Config.magicNumber);
         Config.items.forEach(item -> LOGGER.info("ITEM >> {}", item.toString()));
 
-        // ✅ Start WebSocket server
-        new Thread(() -> {
-            try {
-                WebSocketTNTListener server = new WebSocketTNTListener(9001);
-                server.start();
-                LOGGER.info("WebSocket server started on port 9001");
-            } catch (Exception e) {
-                LOGGER.error("WebSocket server failed to start", e);
-            }
-        }).start();
+        // WebSocket server is started via the /websocket start command
     }
 
     private void addCreative(BuildCreativeModeTabContentsEvent event) {


### PR DESCRIPTION
## Summary
- remove auto start of WebSocket server
- launch socket from `/websocket start` command in a separate thread
- show documentation that server is launched via command

## Testing
- `./OurMod/gradlew --version` *(fails: Could not find or load main class org.gradle.wrapper.GradleWrapperMain)*

------
https://chatgpt.com/codex/tasks/task_e_68694f08a2748333bac3751daf616601